### PR TITLE
task/BAN-112 Update get asset endpoint with contains pii field

### DIFF
--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -3616,8 +3616,9 @@
         "properties": {
           "contains_pii": {
             "type": "boolean",
-            "description": "Is the asset contains PII",
-            "example": false
+            "description": "The asset contain PII value",
+            "example": false,
+            "nullable": true
           },
           "id": {
             "type": "number",

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -3614,6 +3614,11 @@
         "description": "An asset",
         "type": "object",
         "properties": {
+          "contains_pii": {
+            "type": "boolean",
+            "description": "Is the asset contains PII",
+            "example": false
+          },
           "id": {
             "type": "number",
             "description": "The asset id",
@@ -3733,6 +3738,7 @@
           }
         },
         "required": [
+          "contains_pii",
           "id",
           "title",
           "filename",
@@ -3754,6 +3760,11 @@
         "description": "An asset",
         "type": "object",
         "properties": {
+          "contains_pii": {
+            "type": "boolean",
+            "description": "Is the asset contains PII",
+            "example": false
+          },
           "created_at": {
             "type": "string",
             "description": "The asset created at date",
@@ -3873,6 +3884,7 @@
           }
         },
         "required": [
+          "contains_pii",
           "created_at",
           "extension",
           "filename",

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -3760,11 +3760,6 @@
         "description": "An asset",
         "type": "object",
         "properties": {
-          "contains_pii": {
-            "type": "boolean",
-            "description": "Is the asset contains PII",
-            "example": false
-          },
           "created_at": {
             "type": "string",
             "description": "The asset created at date",
@@ -3884,7 +3879,6 @@
           }
         },
         "required": [
-          "contains_pii",
           "created_at",
           "extension",
           "filename",

--- a/public/refs/components/schemas/Asset.json
+++ b/public/refs/components/schemas/Asset.json
@@ -2,6 +2,11 @@
   "description": "An asset",
   "type": "object",
   "properties": {
+    "contains_pii": {
+      "type": "boolean",
+      "description": "Is the asset contains PII",
+      "example": false
+    },
     "id": {
       "type": "number",
       "description": "The asset id",
@@ -118,9 +123,10 @@
       "type": "boolean",
       "description": "Is the asset processed",
       "example": true
-    }
+    },
   },
   "required": [
+    "contains_pii",
     "id",
     "title",
     "filename",

--- a/public/refs/components/schemas/Asset.json
+++ b/public/refs/components/schemas/Asset.json
@@ -4,8 +4,9 @@
   "properties": {
     "contains_pii": {
       "type": "boolean",
-      "description": "Is the asset contains PII",
-      "example": false
+      "description": "The asset contain PII value",
+      "example": false,
+      "nullable": true
     },
     "id": {
       "type": "number",

--- a/public/refs/components/schemas/Asset.json
+++ b/public/refs/components/schemas/Asset.json
@@ -123,7 +123,7 @@
       "type": "boolean",
       "description": "Is the asset processed",
       "example": true
-    },
+    }
   },
   "required": [
     "contains_pii",

--- a/public/refs/components/schemas/AssetShort.json
+++ b/public/refs/components/schemas/AssetShort.json
@@ -2,11 +2,6 @@
   "description": "An asset",
   "type": "object",
   "properties": {
-    "contains_pii": {
-      "type": "boolean",
-      "description": "Is the asset contains PII",
-      "example": false
-    },
     "created_at": {
       "type": "string",
       "description": "The asset created at date",
@@ -126,7 +121,6 @@
     }
   },
   "required": [
-    "contains_pii",
     "created_at",
     "extension",
     "filename",

--- a/public/refs/components/schemas/AssetShort.json
+++ b/public/refs/components/schemas/AssetShort.json
@@ -2,6 +2,11 @@
   "description": "An asset",
   "type": "object",
   "properties": {
+    "contains_pii": {
+      "type": "boolean",
+      "description": "Is the asset contains PII",
+      "example": false
+    },
     "created_at": {
       "type": "string",
       "description": "The asset created at date",
@@ -121,6 +126,7 @@
     }
   },
   "required": [
+    "contains_pii",
     "created_at",
     "extension",
     "filename",


### PR DESCRIPTION
# Version

- 4.0.0

# Ticket URL

- https://linear.app/chillipharm/issue/BAN-112/update-get-asset-endpoint-with-contains-pii-field

# Changes Made

- update asset model with contains_pii field

# Checklist

Please verify this checklist so that you are sure this is ready for review.

- [x] Updated `package.json` & `schema.json` versions - they need to be the same
- [x] All objects have a properites list, `required` array and `additionalProperties` set to `false`
