### PR TITLE
task/BAN-57 Endpoint to fetch asset information is not protected by any

### DIFF
--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -1633,11 +1633,11 @@
     },
     "/accounts/{account_id}/sites/{site_number}/subjects/{subject_number}/study_events/{study_event_identifier}/study_procedures/{study_procedure_identifier}/assets/{asset_id}": {
       "get": {
-        "summary": "Get an asset in a trial container",
-        "description": "Get an asset in a trial container",
-        "operationId": "getAsset",
+        "summary": "Get an asset in a study procedure",
+        "description": "Get an asset in a study procedure",
+        "operationId": "getStudyProcedureAsset",
         "tags": [
-          "Site Assets"
+          "Study Procedure Assets"
         ],
         "security": [
           {

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -3997,43 +3997,28 @@
             "example": false,
             "nullable": true
           },
-          "id": {
-            "type": "number",
-            "description": "The asset id",
-            "example": 1
-          },
-          "title": {
-            "type": "string",
-            "description": "The asset title",
-            "example": "image.png"
-          },
-          "document_type": {
-            "type": "string",
-            "description": "The asset document type",
-            "example": "image"
-          },
-          "filename": {
-            "type": "string",
-            "description": "The asset filename",
-            "example": "image.png"
-          },
           "created_at": {
             "type": "string",
             "description": "The asset created at date",
             "example": "2024-03-27T15:46:56.845Z"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/User"
           },
           "extension": {
             "type": "string",
             "description": "The asset extension",
             "example": "png"
           },
-          "created_by": {
-            "$ref": "#/components/schemas/User"
-          },
-          "media_type": {
+          "filename": {
             "type": "string",
-            "description": "The asset media type",
-            "example": "image"
+            "description": "The asset filename",
+            "example": "image.png"
+          },
+          "id": {
+            "type": "number",
+            "description": "The asset id",
+            "example": 1
           },
           "media": {
             "oneOf": [
@@ -4072,6 +4057,21 @@
               }
             ]
           },
+          "media_type": {
+            "type": "string",
+            "description": "The asset media type",
+            "example": "image"
+          },
+          "position": {
+            "type": "number",
+            "description": "The asset position",
+            "example": 16
+          },
+          "processed": {
+            "type": "boolean",
+            "description": "Is the asset processed",
+            "example": true
+          },
           "thumbnails": {
             "type": "object",
             "properties": {
@@ -4088,49 +4088,20 @@
                 "nullable": true
               }
             }
-          },
-          "study_procedure_identifier": {
-            "type": "string",
-            "description": "The asset study procedure identifier",
-            "example": "NSTAR"
-          },
-          "study_event_identifier": {
-            "type": "string",
-            "description": "The asset study event identifier",
-            "example": "DAY1"
-          },
-          "subject_number": {
-            "type": "string",
-            "description": "The asset subject number",
-            "example": "E0001003"
-          },
-          "position": {
-            "type": "number",
-            "description": "The asset position",
-            "example": 16
-          },
-          "processed": {
-            "type": "boolean",
-            "description": "Is the asset processed",
-            "example": true
           }
         },
         "required": [
           "contains_pii",
-          "id",
-          "title",
-          "filename",
           "created_at",
-          "extension",
           "created_by",
-          "media_type",
+          "extension",
+          "filename",
+          "id",
           "media",
-          "thumbnails",
-          "study_procedure_identifier",
-          "study_event_identifier",
-          "subject_number",
+          "media_type",
           "position",
-          "processed"
+          "processed",
+          "thumbnails"
         ],
         "additionalProperties": false
       },

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -1632,6 +1632,112 @@
       }
     },
     "/accounts/{account_id}/sites/{site_number}/subjects/{subject_number}/study_events/{study_event_identifier}/study_procedures/{study_procedure_identifier}/assets/{asset_id}": {
+      "get": {
+        "summary": "Get an asset in a trial container",
+        "description": "Get an asset in a trial container",
+        "operationId": "getAsset",
+        "tags": [
+          "Site Assets"
+        ],
+        "security": [
+          {
+            "userSessionKey": [],
+            "chillipharmSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "description": "The account id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
+          },
+          {
+            "name": "site_number",
+            "in": "path",
+            "description": "The site number",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "SITE1"
+            }
+          },
+          {
+            "name": "subject_number",
+            "in": "path",
+            "description": "The subject number",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "12345678"
+            }
+          },
+          {
+            "name": "study_event_identifier",
+            "in": "path",
+            "description": "The study event identifier",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "VISIT1"
+            }
+          },
+          {
+            "name": "study_procedure_identifier",
+            "in": "path",
+            "description": "The study procedure identifier",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "PROC1"
+            }
+          },
+          {
+            "name": "asset_id",
+            "in": "path",
+            "description": "The asset id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
       "put": {
         "summary": "Update an asset in a study procedure",
         "description": "Update an asset in a study procedure",

--- a/public/refs/components/schemas/Asset.json
+++ b/public/refs/components/schemas/Asset.json
@@ -8,43 +8,28 @@
       "example": false,
       "nullable": true
     },
-    "id": {
-      "type": "number",
-      "description": "The asset id",
-      "example": 1
-    },
-    "title": {
-      "type": "string",
-      "description": "The asset title",
-      "example": "image.png"
-    },
-    "document_type": {
-      "type": "string",
-      "description": "The asset document type",
-      "example": "image"
-    },
-    "filename": {
-      "type": "string",
-      "description": "The asset filename",
-      "example": "image.png"
-    },
     "created_at": {
       "type": "string",
       "description": "The asset created at date",
       "example": "2024-03-27T15:46:56.845Z"
+    },
+    "created_by": {
+      "$ref": "./User.json"
     },
     "extension": {
       "type": "string",
       "description": "The asset extension",
       "example": "png"
     },
-    "created_by": {
-      "$ref": "./User.json"
-    },
-    "media_type": {
+    "filename": {
       "type": "string",
-      "description": "The asset media type",
-      "example": "image"
+      "description": "The asset filename",
+      "example": "image.png"
+    },
+    "id": {
+      "type": "number",
+      "description": "The asset id",
+      "example": 1
     },
     "media": {
       "oneOf": [
@@ -83,6 +68,21 @@
         }
       ]
     },
+    "media_type": {
+      "type": "string",
+      "description": "The asset media type",
+      "example": "image"
+    },
+    "position": {
+      "type": "number",
+      "description": "The asset position",
+      "example": 16
+    },
+    "processed": {
+      "type": "boolean",
+      "description": "Is the asset processed",
+      "example": true
+    },
     "thumbnails": {
       "type": "object",
       "properties": {
@@ -99,49 +99,20 @@
           "nullable": true
         }
       }
-    },
-    "study_procedure_identifier": {
-      "type": "string",
-      "description": "The asset study procedure identifier",
-      "example": "NSTAR"
-    },
-    "study_event_identifier": {
-      "type": "string",
-      "description": "The asset study event identifier",
-      "example": "DAY1"
-    },
-    "subject_number": {
-      "type": "string",
-      "description": "The asset subject number",
-      "example": "E0001003"
-    },
-    "position": {
-      "type": "number",
-      "description": "The asset position",
-      "example": 16
-    },
-    "processed": {
-      "type": "boolean",
-      "description": "Is the asset processed",
-      "example": true
     }
   },
   "required": [
     "contains_pii",
-    "id",
-    "title",
-    "filename",
     "created_at",
-    "extension",
     "created_by",
-    "media_type",
+    "extension",
+    "filename",
+    "id",
     "media",
-    "thumbnails",
-    "study_procedure_identifier",
-    "study_event_identifier",
-    "subject_number",
+    "media_type",
     "position",
-    "processed"
+    "processed",
+    "thumbnails"
   ],
   "additionalProperties": false
 }

--- a/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures_{study_procedure_identifier}_assets_{asset_id}.json
+++ b/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures_{study_procedure_identifier}_assets_{asset_id}.json
@@ -1,4 +1,110 @@
 {
+  "get": {
+    "summary": "Get an asset in a trial container",
+    "description": "Get an asset in a trial container",
+    "operationId": "getAsset",
+    "tags": [
+      "Site Assets"
+    ],
+    "security": [
+      {
+        "userSessionKey": [],
+        "chillipharmSession": []
+      }
+    ],
+    "parameters": [
+      {
+        "name": "account_id",
+        "in": "path",
+        "description": "The account id",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "1"
+        }
+      },
+      {
+        "name": "site_number",
+        "in": "path",
+        "description": "The site number",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "SITE1"
+        }
+      },
+      {
+        "name": "subject_number",
+        "in": "path",
+        "description": "The subject number",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "12345678"
+        }
+      },
+      {
+        "name": "study_event_identifier",
+        "in": "path",
+        "description": "The study event identifier",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "VISIT1"
+        }
+      },
+      {
+        "name": "study_procedure_identifier",
+        "in": "path",
+        "description": "The study procedure identifier",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "PROC1"
+        }
+      },
+      {
+        "name": "asset_id",
+        "in": "path",
+        "description": "The asset id",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "1"
+        }
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "OK",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "../components/schemas/Asset.json"
+            }
+          }
+        }
+      },
+      "400": {
+        "$ref": "../components/responses/BadRequest.json"
+      },
+      "401": {
+        "$ref": "../components/responses/Unauthorized.json"
+      },
+      "403": {
+        "$ref": "../components/responses/Forbidden.json"
+      },
+      "404": {
+        "$ref": "../components/responses/NotFound.json"
+      },
+      "409": {
+        "$ref": "../components/responses/Conflict.json"
+      },
+      "500": {
+        "$ref": "../components/responses/InternalServerError.json"
+      }
+    }
+  },
   "put": {
     "summary": "Update an asset in a study procedure",
     "description": "Update an asset in a study procedure",

--- a/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures_{study_procedure_identifier}_assets_{asset_id}.json
+++ b/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures_{study_procedure_identifier}_assets_{asset_id}.json
@@ -1,10 +1,10 @@
 {
   "get": {
-    "summary": "Get an asset in a trial container",
-    "description": "Get an asset in a trial container",
+    "summary": "Get an asset in a study procedure",
+    "description": "Get an asset in a study procedure",
     "operationId": "getAsset",
     "tags": [
-      "Site Assets"
+      "Study Procedure Assets"
     ],
     "security": [
       {

--- a/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures_{study_procedure_identifier}_assets_{asset_id}.json
+++ b/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures_{study_procedure_identifier}_assets_{asset_id}.json
@@ -2,7 +2,7 @@
   "get": {
     "summary": "Get an asset in a study procedure",
     "description": "Get an asset in a study procedure",
-    "operationId": "getAsset",
+    "operationId": "getStudyProcedureAsset",
     "tags": [
       "Study Procedure Assets"
     ],


### PR DESCRIPTION
## 📝 Description

> Please include a summary of the change and the related issue(s).
> What is the motivation behind this PR?

Adding `GET` to the endpoint:
`/api/v1/accounts/:account_id/sites/:site_number/subjects/:subject_number/study_events/:study_event_identifier/study_procedures/:study_procedure_identifier/assets/:asset_id`
---

## ✅ Type of Change

> Check all that apply:

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Refactor ♻️
- [ ] Documentation update 📚
- [ ] Test update 🧪
- [ ] CI/CD update ⚙️
- [ ] Other (please describe):

---

## 🔍 Changes Made

- [ ] Updated `package.json` & `schema.json` versions - they need to be the same
- [ ] All objects have a properites list, `required` array and `additionalProperties` set to `false`
- [x] Update `fullSchema.json` by running `npm run bundle`
- [x] Verify there is no issues by running `npm run lint`