### PR TITLE
Feature/ptm 247 migrate access pat token to GitHub app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,17 +79,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: 2786925
-          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
       - name: Delete Releases
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs').promises;
 
@@ -180,13 +173,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: 2786925
-          private-key: ${{ secrets.API_SPEC_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -198,7 +184,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ github.token }}
           publish_dir: ./dist
 
   publish-to-swagger-hub:


### PR DESCRIPTION
<!-- markdownlint-disable MD033 -->

## 📝 Description/Version

Changed from GitHub App token to default GitHub action token in publish and delete package job.

Resolves: #247

---

## ✅ Type of Change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Refactor ♻️
- [ ] Tooling/Scripts 🛠️
- [ ] Test update 🧪
- [ ] Other (please describe):

---

## 🔍 Changes Made

> Briefly list the key changes:

---

## Impact

**Breaking changes:**

- [x] ✅ No breaking changes
- [ ] ⚠️ Yes - breaking changes (explain below)

> If breaking change, describe the impact

---

## 🧩 Checklist

> Make sure you've done these:

- [ ] Updated `package.json` & `schema.json` versions - they need to be the same
- [ ] Verify there are no issues with the schema.json by running `npm run verify`
- [ ] All objects have a properites list, `required` array and `additionalProperties` set to `false`

---

## Post-Merge Steps

<!-- Any manual steps needed after merge -->

-
-

---

## 🙋‍♂️ Notes for Reviewers

> Anything specific to watch out for, tricky parts, assumptions made, or questions to raise?
