### PR TITLE
fix/3425 bump lodash to 4.18.1 (critical SCA)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5897,9 +5897,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {


### PR DESCRIPTION
## Summary

**Security issue:** Yes — Dependency (SCA) finding: critical + two medium lodash advisories flagged by Aikido for sites-api-specifications.

lodash was pinned at 4.17.21 in the lockfile. This PR bumps it to 4.18.1 (the current latest published release), which remediates the reported vulnerabilities. lodash is a transitive dependency (pulled in via minim / swagger-ui-react), present only in `package-lock.json`, so this is a lockfile-only bump. 4.18.1 satisfies both parent ranges (`^4.15.0` and `^4.17.21`); verified internally consistent via `npm install --package-lock-only`.

## Changed files

- `package-lock.json` — bump `node_modules/lodash` from 4.17.21 to 4.18.1 (version, resolved URL, integrity hash from the npm registry)

## Fix type

Dependency (SCA) / Dependency Version Bump (from triage)

---

Automated fix for [AB#3425](https://dev.azure.com/chillipharm/Issues%20and%20Vulnerabilities/_workitems/edit/3425), generated by the ChilliPharm fix-flow action agent from a triaged work item. Review before merging like any other PR.