### PR TITLE
feature/3430 Retrieve the subjects within a site a user can access (API) | AB#3430

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chillibean/sites-api-specifications",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chillibean/sites-api-specifications",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chillibean/sites-api-specifications",
   "private": true,
-  "version": "4.10.0",
+  "version": "4.11.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -5440,6 +5440,11 @@
             "description": "The serial number of the subject",
             "example": "E001004"
           },
+          "number_of_study_events": {
+            "type": "number",
+            "description": "The number of study events assigned to this subject",
+            "example": 5
+          },
           "study_arm": {
             "anyOf": [
               {
@@ -5466,6 +5471,7 @@
           "created_by",
           "id",
           "number",
+          "number_of_study_events",
           "unscheduled_study_event_serial_number"
         ],
         "additionalProperties": false

--- a/public/fullSchema.json
+++ b/public/fullSchema.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "version": "4.10.0",
+    "version": "4.11.0",
     "title": "Sites API",
     "description": "This is the api specifications for all things related to sites.",
     "contact": {

--- a/public/refs/components/schemas/StudySubject.json
+++ b/public/refs/components/schemas/StudySubject.json
@@ -48,6 +48,11 @@
       "description": "The serial number of the subject",
       "example": "E001004"
     },
+    "number_of_study_events": {
+      "type": "number",
+      "description": "The number of study events assigned to this subject",
+      "example": 5
+    },
     "study_arm": {
       "anyOf": [
         {
@@ -74,6 +79,7 @@
     "created_by",
     "id",
     "number",
+    "number_of_study_events",
     "unscheduled_study_event_serial_number"
   ],
   "additionalProperties": false

--- a/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures.json
+++ b/public/refs/paths/accounts_{account_id}_sites_{site_number}_subjects_{subject_number}_study_events_{study_event_identifier}_study_procedures.json
@@ -186,22 +186,22 @@
         }
       },
       "400": {
-        "$ref": "#/components/responses/BadRequest"
+        "$ref": "../components/responses/BadRequest.json"
       },
       "401": {
-        "$ref": "#/components/responses/Unauthorized"
+        "$ref": "../components/responses/Unauthorized.json"
       },
       "403": {
-        "$ref": "#/components/responses/Forbidden"
+        "$ref": "../components/responses/Forbidden.json"
       },
       "404": {
-        "$ref": "#/components/responses/NotFound"
+        "$ref": "../components/responses/NotFound.json"
       },
       "409": {
-        "$ref": "#/components/responses/Conflict"
+        "$ref": "../components/responses/Conflict.json"
       },
       "500": {
-        "$ref": "#/components/responses/InternalServerError"
+        "$ref": "../components/responses/InternalServerError.json"
       }
     }
   }

--- a/public/schema.json
+++ b/public/schema.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "version": "4.10.0",
+    "version": "4.11.0",
     "title": "Sites API",
     "description": "This is the api specifications for all things related to sites.",
     "contact": {


### PR DESCRIPTION
<!-- markdownlint-disable MD033 -->

## 📝 Description/Version

<!-- Brief summary of changes and what problem this solves -->

**Resolves:** [AB#3430](https://dev.azure.com/chillipharm/Video%20Capture%20App/_workitems/edit/3430)

---

## ✅ Type of Change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Refactor ♻️
- [ ] Tooling/Scripts 🛠️
- [ ] Test update 🧪
- [ ] Other (please describe):

---

## 🔍 Changes Made

> Briefly list the key changes:

- added new property to StudySubject schema required by mobile API

---

## Impact

**Breaking changes:**

- [ ] ✅ No breaking changes
- [ ] ⚠️ Yes - breaking changes (explain below)

> If breaking change, describe the impact

---

## 🧩 Checklist

> Make sure you've done these:

- [x] Updated `package.json` & `schema.json` versions - they need to be the same
- [x] Verify there are no issues with the schema.json by running `npm run verify`
- [x] All objects have a properites list, `required` array and `additionalProperties` set to `false`

---

## Post-Merge Steps

<!-- Any manual steps needed after merge -->

-
-

---

## 🙋‍♂️ Notes for Reviewers

> Anything specific to watch out for, tricky parts, assumptions made, or questions to raise?
